### PR TITLE
refactor: change custom errors to be under general ExpansionError class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sh-expand"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name="Michael Greenberg", email="michael@greenberg.science" },
   { name="Konstantinos Kallas", email="konstantinos.kallas@hotmail.com" },

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(name='sh-expand',
-      version='0.1.3',
+      version='0.1.4',
       packages=['sh_expand'],
       ## Necessary for the markdown to be properly rendered
       long_description=long_description,

--- a/sh_expand/expand.py
+++ b/sh_expand/expand.py
@@ -190,26 +190,29 @@ def safe_if(node):
 #   + commands just set the structural bits appropriately
 
 # when early expansion detects an error
-class EarlyError(RuntimeError):
+class ExpansionError(RuntimeError): 
+    pass 
+
+class EarlyError(ExpansionError):
     def __init__(self, arg):
         self.arg = arg
 
-class StuckExpansion(RuntimeError):
+class StuckExpansion(ExpansionError):
     def __init__(self, reason, *info):
         self.reason = reason
         self.info = info
 
-class ImpureExpansion(RuntimeError):
+class ImpureExpansion(ExpansionError):
     def __init__(self, reason, *info):
         self.reason = reason
         self.info = info
 
-class Unimplemented(RuntimeError):
+class Unimplemented(ExpansionError):
     def __init__(self, msg, ast):
         self.msg = msg
         self.ast = ast
 
-class InvalidVariable(RuntimeError):
+class InvalidVariable(ExpansionError):
     def __init__(self, var, reason):
         self.var = var
         self.reason = reason


### PR DESCRIPTION
`ExpansionError` will be imported to pash_compiler to be caught there 