### PR TITLE
fix glob check

### DIFF
--- a/sh_expand/expand.py
+++ b/sh_expand/expand.py
@@ -316,7 +316,7 @@ def expand_arg(arg_chars, exp_state, quoted = False):
 
 def expand_arg_char(arg_char: ArgChar, quoted, exp_state):
     if isinstance(arg_char, CArgChar):
-        if arg_char.char in ['*', '?', '{', '}', '[', ']'] and not quoted:
+        if chr(arg_char.char) in ['*', '?', '{', '}', '[', ']'] and not quoted:
             raise Unimplemented("globbing", arg_char)
 
         return [arg_char]


### PR DESCRIPTION
`CArgChar`'s `char` field is an int. Hence 

`arg_char.char in ['*', '?', '{', '}', '[', ']']` 

is comparing an integer to a list of strings and hence will always be false. 

For example, if `CArgChar` is `*` this will check 

`42 in ['*', '?', '{', '}', '[', ']']` which is wrong.

Maybe we don't actually care that this is always false, in which case this check should be deleted.