### PR TITLE
Fix for handling positional parameter expansion

### DIFF
--- a/sh_expand/env_vars_util.py
+++ b/sh_expand/env_vars_util.py
@@ -182,7 +182,7 @@ def set_special_parameters(variables: dict):
         new_vars['#'] = ia_t, str(len(input_args))
         for i, arg in enumerate(input_args):
             index = i + 1
-            new_vars[str(index)] = input_args[i]
+            new_vars[str(index)] = ia_t, input_args[i]
 
     if not exit_status is None:
         new_vars['?'] = es_t, exit_status


### PR DESCRIPTION
Currently, sh_expand fails to expand positional parameters in PaSh because the additional type annotation that PaSh expects is missing from the expansion of the positional parameters.

Positional parameters are heavily used in newer benchmarks specifically, and it enables changing the inputs to the script through the command line directly instead of manually modifying scripts.

When positional parameters are present in the script, PaSh silently reverts to sequential shell execution, making it seem like it fails to accelerate computation when it may actually be able to accelerate.  This change would also positively impact the user experience for PaSh overall.