### PR TITLE
Removed ubuntu-20.04 from workflow since its now deprecated

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,6 @@ jobs:
         fail-fast: false
         matrix:
           os: 
-            - ubuntu-20.04
             - ubuntu-22.04
             - ubuntu-24.04
       runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Removed unsupported ubuntu version, 20.04, from github LocalTests workflow

See
https://github.com/actions/runner-images/issues/11101